### PR TITLE
Added new hotkey Ctrl+F to search command history

### DIFF
--- a/htmltads/htmlinp.cpp
+++ b/htmltads/htmlinp.cpp
@@ -612,6 +612,8 @@ int CHtmlInputBuf::select_prev_hist()
 int CHtmlInputBuf::select_prev_hist_prefix(const textchar_t *pre, size_t len)
 {
     size_t cur;
+    /* abort search after 2 rounds not finding a result */
+    bool second_round = false;
 
     /* if there's nothing in the history buffer, ignore this */
     if (histcnt_ == 0)
@@ -650,7 +652,16 @@ int CHtmlInputBuf::select_prev_hist_prefix(const textchar_t *pre, size_t len)
         }
 
         /* move to the previous line, wrapping at the start of the list */
-        cur = (cur == 0 ? histcnt_ : cur) - 1;
+        if(cur == 0){
+            if(second_round){
+                break;
+            }else{
+                cur = histcnt_ - 1;
+                second_round = true;
+            }
+        }else{
+            cur--;
+        }
     }
 
     /* we didn't find a match; ignore it */

--- a/src/syswininput.cc
+++ b/src/syswininput.cc
@@ -281,6 +281,9 @@ CHtmlSysWinInputQt::keyPressEvent( QKeyEvent* e )
     } else if (e->matches(QKeySequence::MoveToNextLine)) {
         this->fTadsBuffer->select_next_hist();
         this->fCastDispWidget->clearSelection();
+    } else if (e->matches(QKeySequence::Find)) {
+        this->fTadsBuffer->select_prev_hist_prefix();
+        this->fCastDispWidget->clearSelection();
     } else if (e->matches(QKeySequence::SelectPreviousChar)) {
         if (not this->fTadsBuffer->has_sel_range()) {
             this->fCastDispWidget->clearSelection();


### PR DESCRIPTION
It only matches the prefix, not a real search. Type in the prefix and then
press Ctrl+F to search for a previous command with this prefix. Press again to
cycle through the search entries. If nothing is found, nothing will happen.
