### PR TITLE
Prevent segfault if no version data retrieved from server.

### DIFF
--- a/src/syswingroup.cc
+++ b/src/syswingroup.cc
@@ -305,13 +305,15 @@ CHtmlSysWinGroupQt::fReplyFinished( QNetworkReply* reply )
 
     // Do the same with the retrieved version.
     str = QString::fromUtf8(reply->readLine(10));
-    // Chop the newline at the end, if there is one.
-    if (str.endsWith(QChar::fromLatin1('\n'))) {
-        str.chop(1);
+    int newVersion = 0;
+    if (str.length() > 3) {
+      // Chop the newline at the end, if there is one.
+      if (str.endsWith(QChar::fromLatin1('\n'))) {
+      	  str.chop(1);
+      }
+      strList = str.split(QChar::fromLatin1('.'));
+      newVersion = QT_VERSION_CHECK(strList.at(0).toInt(), strList.at(1).toInt(), strList.at(2).toInt());
     }
-    strList = str.split(QChar::fromLatin1('.'));
-    int newVersion = QT_VERSION_CHECK(strList.at(0).toInt(), strList.at(1).toInt(), strList.at(2).toInt());
-
     QMessageBox* msgBox = new QMessageBox(this);
     msgBox->setTextFormat(Qt::RichText);
     msgBox->setWindowTitle(tr("Check for Updates"));


### PR DESCRIPTION
Check that we really read new version string. Silently exit if not.
