### PR TITLE
ignore .qmake.stash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /qtads
 /qtads.pro.user*
 /qrc_resources.cpp
+/.qmake.stash


### PR DESCRIPTION
to make it easier to use `git-build-package`