### PR TITLE
Port to Qt 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /qtads.pro.user*
 /qrc_resources.cpp
 /.qmake.stash
+.cache
+compile_commands.json

--- a/qtads.pro
+++ b/qtads.pro
@@ -20,6 +20,9 @@ equals(QT_MAJOR_VERSION, 5) {
         QMAKE_CXXFLAGS += -std=c++1z
     }
 }
+greaterThan(QT_MAJOR_VERSION,5) {
+    QT += core5compat
+}
 
 macx {
     ICON = QTads.icns

--- a/qtads.pro
+++ b/qtads.pro
@@ -20,9 +20,6 @@ equals(QT_MAJOR_VERSION, 5) {
         QMAKE_CXXFLAGS += -std=c++1z
     }
 }
-greaterThan(QT_MAJOR_VERSION,5) {
-    QT += core5compat
-}
 
 macx {
     ICON = QTads.icns

--- a/src/kcolorbutton.cc
+++ b/src/kcolorbutton.cc
@@ -232,9 +232,9 @@ void KColorButton::paintEvent(QPaintEvent *)
     if (hasFocus()) {
         QRect focusRect = style->subElementRect(QStyle::SE_PushButtonFocusRect, &butOpt, this);
         QStyleOptionFocusRect focusOpt;
-        focusOpt.init(this);
+        focusOpt.initFrom(this);
         focusOpt.rect            = focusRect;
-        focusOpt.backgroundColor = palette().background().color();
+        focusOpt.backgroundColor = palette().window().color();
         style->drawPrimitive(QStyle::PE_FrameFocusRect, &focusOpt, &painter, this);
     }
 }
@@ -243,16 +243,14 @@ QSize KColorButton::sizeHint() const
 {
     QStyleOptionButton opt;
     d->initStyleOption(&opt);
-    return style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(40, 15), this).
-           expandedTo(QApplication::globalStrut());
+    return style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(40, 15), this);
 }
 
 QSize KColorButton::minimumSizeHint() const
 {
     QStyleOptionButton opt;
     d->initStyleOption(&opt);
-    return style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(3, 3), this).
-           expandedTo(QApplication::globalStrut());
+    return style()->sizeFromContents(QStyle::CT_PushButton, &opt, QSize(3, 3), this);
 }
 
 void KColorButton::dragEnterEvent(QDragEnterEvent *event)
@@ -294,7 +292,7 @@ void KColorButton::mouseMoveEvent(QMouseEvent *e)
 {
     if ((e->buttons() & Qt::LeftButton) &&
             (e->pos() - d->mPos).manhattanLength() > QApplication::startDragDistance()) {
-        _k_createDrag(color(), this)->start();
+        _k_createDrag(color(), this)->exec();
         setDown(false);
     }
 }

--- a/src/missing.cc
+++ b/src/missing.cc
@@ -1,7 +1,9 @@
 // This is copyrighted software. More information is at the end of this file.
 #include <QDebug>
 #include <QString>
-#include <QTextCodec>
+#include <QStringConverter>
+#include <QStringDecoder>
+#include <QStringEncoder>
 #include <cctype>
 #include <cstdlib>
 #include <cstring>

--- a/src/osqt.cc
+++ b/src/osqt.cc
@@ -678,7 +678,7 @@ void os_get_special_path(
 
     case OS_GSP_T3_APP_DATA:
     case OS_GSP_LOGFILE: {
-        const auto dirStr = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+        const auto dirStr = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
         QDir dir(dirStr);
         QByteArray result;
         // Create the directory if it doesn't exist.

--- a/src/sysframe.h
+++ b/src/sysframe.h
@@ -75,6 +75,10 @@ private:
 
     int fPendingWaitForKeystrokeCmd = 0;
 
+    // Are we running in embed mode (i.e. do we need to print out our window ID
+    // so another application can capture it?)
+    bool fEmbedMode;
+
     // Run the game file contained in fNextGame.
     void fRunGame();
 
@@ -108,7 +112,7 @@ signals:
 public slots:
     // Replacement for main().  We need this so that we can start the Tads VM
     // after the QApplication main event loop has started.
-    void entryPoint(QString gameFileName);
+    void entryPoint(QString gameFileName, bool embed = false);
 
 public:
     CHtmlSysFrameQt(
@@ -181,6 +185,11 @@ public:
     auto nonStopMode() -> bool
     {
         return fNonStopMode;
+    }
+
+    void setEmbedMode(bool fmode)
+    {
+        fEmbedMode = fmode;
     }
 
     // Recalculate and adjust the sizes of all HTML banners.

--- a/src/syswin.cc
+++ b/src/syswin.cc
@@ -539,7 +539,7 @@ auto CHtmlSysWinQt::measure_text(CHtmlSysFont* font, const textchar_t* str, size
     // subsequent text should be drawn.  This is really what our caller needs
     // to know, otherwise letters will start jumping left and right when
     // selecting text or moving the text cursor.
-    return {tmpMetr.width(QString::fromUtf8(str, len)), tmpMetr.height()};
+    return {tmpMetr.horizontalAdvance(QString::fromUtf8(str, len)), tmpMetr.height()};
 }
 
 auto CHtmlSysWinQt::get_max_chars_in_width(
@@ -614,7 +614,7 @@ void CHtmlSysWinQt::draw_text_space(int hilite, long x, long y, CHtmlSysFont* fo
     // Construct a string of spaces that's at least 'width' pixels wide.
     QString str(' ');
     const QFontMetrics& metr = painter.fontMetrics();
-    while (metr.width(str) < wid) {
+    while (metr.horizontalAdvance(str) < wid) {
         str.append(' ');
     }
 

--- a/src/syswin.h
+++ b/src/syswin.h
@@ -1,8 +1,8 @@
 // This is copyrighted software. More information is at the end of this file.
 #pragma once
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QScrollArea>
+#include <QScreen>
 
 #include "config.h"
 #include "globals.h"
@@ -154,7 +154,7 @@ public:
 
     auto get_pix_per_inch() -> long override
     {
-        return QApplication::desktop()->logicalDpiX();
+        return QApplication::primaryScreen()->logicalDotsPerInchX();
     }
 
     auto measure_text(class CHtmlSysFont* font, const textchar_t* str, size_t len, int* ascent)

--- a/src/syswininput.cc
+++ b/src/syswininput.cc
@@ -5,7 +5,9 @@
 #include <QLabel>
 #include <QScrollBar>
 #include <QStatusBar>
-#include <QTextCodec>
+#include <QStringConverter>
+#include <QStringDecoder>
+#include <QStringEncoder>
 #include <QTime>
 #include <QTimer>
 #include <QUrl>
@@ -215,7 +217,8 @@ void CHtmlSysWinInputQt::keyPressEvent(QKeyEvent* e)
         fTadsBuffer.start_of_line(false);
         fCastDispWidget->clearSelection();
     } else if (
-        e->matches(QKeySequence::MoveToEndOfLine) or e->matches(QKeySequence::MoveToEndOfBlock)) {
+        e->matches(QKeySequence::MoveToEndOfLine) or e->matches(QKeySequence::MoveToEndOfBlock))
+    {
         fTadsBuffer.end_of_line(false);
         fCastDispWidget->clearSelection();
     } else if (e->matches(QKeySequence::InsertParagraphSeparator)) {
@@ -285,7 +288,8 @@ void CHtmlSysWinInputQt::keyPressEvent(QKeyEvent* e)
         }
         fTadsBuffer.start_of_line(true);
     } else if (
-        e->matches(QKeySequence::SelectEndOfLine) or e->matches(QKeySequence::SelectEndOfBlock)) {
+        e->matches(QKeySequence::SelectEndOfLine) or e->matches(QKeySequence::SelectEndOfBlock))
+    {
         if (not fTadsBuffer.has_sel_range()) {
             fCastDispWidget->clearSelection();
         }
@@ -484,11 +488,11 @@ void CHtmlSysWinInputQt::getInput(
     if (qFrame->tads3()) {
         strncpy(buf, fTadsBuffer.getbuf(), len);
     } else {
-        QTextCodec* codec = QTextCodec::codecForName(qFrame->settings().tads2Encoding);
+        QStringDecoder fromUnicode{
+            QStringConverter::encodingForName(qFrame->settings().tads2Encoding).value()};
         strncpy(
             buf,
-            codec->fromUnicode(QString::fromUtf8(fTadsBuffer.getbuf(), fTadsBuffer.getlen()))
-                .constData(),
+            fromUnicode(QByteArray::fromRawData(fTadsBuffer.getbuf(), fTadsBuffer.getlen())).data,
             len);
     }
     buf[len] = '\0';

--- a/src/syswininput.cc
+++ b/src/syswininput.cc
@@ -326,7 +326,7 @@ void CHtmlSysWinInputQt::inputMethodEvent(QInputMethodEvent* e)
 
     if (fInputMode == SingleKeyInput) {
         fLastKeyEvent = static_cast<Qt::Key>(0);
-        fLastKeyText = 0;
+        fLastKeyText = '\0';
         // If the keypress doesn't correspond to exactly one character, ignore
         // it.
         if (e->commitString().size() != 1) {
@@ -349,7 +349,7 @@ void CHtmlSysWinInputQt::singleKeyPressEvent(QKeyEvent* event)
     Q_ASSERT(fInputMode == SingleKeyInput);
 
     fLastKeyEvent = static_cast<Qt::Key>(0);
-    fLastKeyText = 0;
+    fLastKeyText = '\0';
 
     switch (event->key()) {
     case 0:
@@ -681,7 +681,7 @@ auto CHtmlSysWinInputQt::getKeypress(unsigned long timeout, bool useTimeout, boo
         default:
             // If we got here, something went wrong.  Just report a
             // space.
-            qWarning() << Q_FUNC_INFO << "unrecognized key event in switch:" << hex
+            qWarning() << Q_FUNC_INFO << "unrecognized key event in switch:" << Qt::hex
                        << fLastKeyEvent;
             return ' ';
         }


### PR DESCRIPTION
In the interests of future maintainability and compatibility, I ported QTADS to Qt6. Everything should work identically, I just went through and replaced uses of constructs that were removed in Qt6. I also removed the uses of `globalStrut` entirely because according to the Qt developers it was [useless and usually set to zero anyways](https://lists.qt-project.org/pipermail/development/2019-December/038110.html).

I also add the capacity to accept command line flags and two flags (`--help` and `--embed`), because I need the ability to tell qtads to print out its window id for [something else I'm working on](https://github.com/alexispurslane/tads3-runner). I hope you don't mind.  