### PR TITLE
Improve build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,9 @@ read on.
 # Dependencies
 
 For QTads to build correctly, you will need to have the Qt5 libraries along with
-their development headers/tools installed. You need at least Qt 5.5.
+their development headers/tools installed. You need at least Qt 5.5. (As of
+January 2024, QTads is not compatible with Qt6.) 
+https://github.com/realnc/qtads/issues/23
 
 If audio support is enabled, you'll also need:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,24 @@ For all other Linux distributions, a self-contained AppImage binary is provided
 on the download page. If you still want to build QTads yourself from source,
 read on.
 
+# Dependencies
+
+For QTads to build correctly, you will need to have the Qt5 libraries along with
+their development headers/tools installed. You need at least Qt 5.5.
+
+If audio support is enabled, you'll also need:
+
+    SDL 2
+    libsndfile
+    libfluidsynth (version 2.x)
+    libvorbisfile
+    libmpg123
+
+Most Linux distributions provide the development versions in packages that have
+"-dev" appended to the package name.
+
+# Building
+
 QTads uses qmake as its build system.  To build it:
 
     cd <directory where you unpacked the QTads sources>
@@ -35,17 +53,3 @@ You can disable audio support when building by running qmake like this instead:
     qmake -config disable-audio
 
 This will produce a version of QTads that does not support audio.
-
-For it to build correctly, you will need to have the Qt5 libraries along with
-their development headers/tools installed. You need at least Qt 5.5.
-
-If audio support is enabled, you'll also need:
-
-    SDL 2
-    libsndfile
-    libfluidsynth (version 2.x)
-    libvorbisfile
-    libmpg123
-
-Most Linux distributions provide the development versions in packages that have
-"-dev" appended to the package name.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,15 @@ If audio support is enabled, you'll also need:
 Most Linux distributions provide the development versions in packages that have
 "-dev" appended to the package name.
 
+On macOS, you can use Homebrew to install dependencies. https://brew.sh/
+
+    brew install qt@5
+
+Homebrew installs QT 5 "keg-only," and it will include a line like this,
+explaining how to add it to your $PATH.
+
+    export PATH="/opt/homebrew/opt/qt@5/bin:$PATH"
+
 # Building
 
 QTads uses qmake as its build system.  To build it:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ First of all, if you're on Gentoo Linux or some other portage-based system, then
 there's no need to continue; QTads is in portage and you can install it normally
 with:
 
-  emerge games-engines/qtads
+    emerge games-engines/qtads
 
 For all other Linux distributions, a self-contained AppImage binary is provided
 on the download page. If you still want to build QTads yourself from source,
@@ -10,9 +10,9 @@ read on.
 
 QTads uses qmake as its build system.  To build it:
 
-  cd <directory where you unpacked the QTads sources>
-  qmake PREFIX=/usr/local
-  make -j4
+    cd <directory where you unpacked the QTads sources>
+    qmake PREFIX=/usr/local
+    make -j4
 
 Replace "-j4" with the amount of CPUs on your machine. "-j2" for a dual-core
 CPU, for example. Specifying PREFIX is optional. If you omit it, the default
@@ -22,7 +22,7 @@ This will create a "qtads" binary which you can then copy and run from anywhere.
 There are no files that need to be installed, although can do a full
 installation as well with:
 
-  make install
+    make install
 
 This will install all files into /usr/local, unless you specified a different
 PREFIX. This will also install a desktop file and MIME information data for
@@ -32,20 +32,20 @@ you don't have write permission for the specified PREFIX.
 
 You can disable audio support when building by running qmake like this instead:
 
-  qmake -config disable-audio
+    qmake -config disable-audio
 
 This will produce a version of QTads that does not support audio.
 
 For it to build correctly, you will need to have the Qt5 libraries along with
 their development headers/tools installed. You need at least Qt 5.5.
-  
+
 If audio support is enabled, you'll also need:
 
-  SDL 2
-  libsndfile
-  libfluidsynth (version 2.x)
-  libvorbisfile
-  libmpg123
+    SDL 2
+    libsndfile
+    libfluidsynth (version 2.x)
+    libvorbisfile
+    libmpg123
 
 Most Linux distributions provide the development versions in packages that have
 "-dev" appended to the package name.


### PR DESCRIPTION
* Convert INSTALL instructions to Markdown
* Mention dependencies before building
* Document that QTads doesn't work with Qt6 https://github.com/realnc/qtads/issues/23
* Document how to install dependencies on macOS